### PR TITLE
Remove link that leads to a 404 page in org README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,2 +1,2 @@
 # New Wind Modpacks
-**Currently working on:** [Waste of World](https://github.com/NewWind-Modpacks/Waste-Of-World) ([Tweaker](https://github.com/NewWind-Modpacks/NWTweaks-WasteOfWorld), Yet to be open-source...)
+**Currently working on:** [Waste of World](https://github.com/NewWind-Modpacks/Waste-Of-World) (Tweaker yet to be open-source...)


### PR DESCRIPTION
Removed the "Tweaker" link that redirected to a 404 page (at least to the public)